### PR TITLE
fix: adding delivery options connection interface registration

### DIFF
--- a/Api/README.md
+++ b/Api/README.md
@@ -11,3 +11,4 @@ php -f bin/magento setup:upgrade
 - Generate an API key in Stores -> Configuration -> Shipstation -> 
 Generate and save api key
 - In ShipStation, specify the api key
+

--- a/Api/etc/di.xml
+++ b/Api/etc/di.xml
@@ -17,4 +17,7 @@
         <plugin name="auctane_index" type="Auctane\Api\Plugin\Controller\Auctane\IndexPlugin"/>
     </type>
 
+    <preference for="Auctane\Api\Api\ConfigureShipstationInterface" type="Auctane\Api\Model\ConfigureShipstation"/>
+    <preference for="Auctane\Api\Api\CheckInterface" type="Auctane\Api\Model\Check"/>
+
 </config>


### PR DESCRIPTION
This got lost in the previous round of merges.