### PR TITLE
Add our team as code owners so email notifications work

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shipstation/ordersource-integrations


### PR DESCRIPTION
This will cause review requests to be automatically sent to our internal team, and help us be more responsive on PRs in the future.