### PR TITLE
Force lower case string for carrier codes

### DIFF
--- a/Api/Model/Action/ShipNotify.php
+++ b/Api/Model/Action/ShipNotify.php
@@ -370,7 +370,7 @@ class ShipNotify
     {
         $shipment = $this->_shipmentFactory->create($order, $qtys, [[
             'number' => $xml->TrackingNumber,
-            'carrier_code' =>  $xml->Carrier,
+            'carrier_code' =>  strtolower($xml->Carrier),
             'title' => strtoupper($xml->Carrier)
         ]]);
 


### PR DESCRIPTION
When an order is updated with a shipment on Magento by Shipstation. The carrier code for the tracking number is not recognized and in turn is set to custom on Magento. This is a problem for merchants who rely on tracking integrations provided by Magento and 3rd party integrations to properly identify tracking numbers by carrier type.