### PR TITLE
fix: php8.1 deprecation warning

### DIFF
--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -176,7 +176,7 @@ class Export
         $this->_attributes = $this->_scopeConfig->getValue(
             $attributes,
             $this->_store
-        );
+        ) ?? '';
 
         $this->_typeBundle = Type::TYPE_BUNDLE;
 


### PR DESCRIPTION
When this property is `null` it triggers a deprecation (and an error in Magento) in php8.1 

```txt
[2023-03-17T20:31:23.667203+00:00] auctane_api.ERROR: Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/vendor/auctane/api/Model/Action/Export.php on line 494 [] []
```