### PR TITLE
Fixes an issue with internal notes being null

### DIFF
--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -309,7 +309,7 @@ class Export
     {
         $internalNotes = array();
         foreach ($order->getStatusHistoryCollection() as $internalNote) {
-            if (empty(trim($internalNote->getComment()))) continue;
+            if (empty(trim($internalNote->getComment() ?? ""))) continue; // You can no longer trim a null string in PHP8.
             array_unshift($internalNotes, $internalNote->getComment());
         }
         $internalNotes = implode("\n", $internalNotes);


### PR DESCRIPTION
PHP 8.2 removed trimming null instead of empty strings. Passing the string with the null coalescing operator fixes it.