### PR TITLE
Update Export.php

### DIFF
--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -258,7 +258,28 @@ class Export
         $this->_getInternalNotes($order);
         $this->addXmlElement("StoreCode", "<![CDATA[{$order->getStore()->getCode()}]]>");
 
-        $this->_getGiftMessageInfo($order);
+        if ($order->getGiftMessageId())
+		{
+			$this->_getGiftMessageInfo($order);
+		} 
+		else 
+		{
+			$item = null;
+			foreach ($order->getItems() as $orderItem) 
+			{
+				if ($orderItem->getGiftMessageId()) 
+				{
+					$item = $orderItem;
+					break;
+				}
+			}
+	
+			if ($item) {
+				$this->_getGiftMessageInfo($item);
+			} else {
+				$this->_getGiftMessageInfo($order);
+			}
+		}
 
         $this->_xmlData .= "\t<Customer>\n";
         $this->addXmlElement("CustomerCode", "<![CDATA[{$order->getCustomerEmail()}]]>");
@@ -477,7 +498,6 @@ class Export
             $this->addXmlElement("UnitPrice", "<![CDATA[{$price}]]>");
             $this->addXmlElement("Quantity", "<![CDATA[". (int)$orderItem->getQtyOrdered() ."]]>");
 
-            $this->_getGiftMessageInfo($orderItem);
             /*
              * Check for the attributes
              */


### PR DESCRIPTION
Fix for gift message import on orders from Amazon (via M2EPro). Amazon orders can have gift messages attached to a line item or whole order, so need loop for gift message import not to be empty.