### PR TITLE
Fix missing orders when an item has a zero price

### DIFF
--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -467,6 +467,10 @@ class Export
                 continue;
             }
 
+            if (empty($price) {
+                $price = '0.00';
+            }
+
             $this->_xmlData .= "\t<Item>\n";
 
             $this->addXmlElement("SKU", "<![CDATA[{$orderItem->getSku()}]]>");


### PR DESCRIPTION
Orders don't import properly when an individual item is sold for 0.00. This fixes that.