### PR TITLE
[Magento 2.4.6 installs broken] Replacing Zend dependency with Laminas

### DIFF
--- a/Api/Model/Carrier/Shipping.php
+++ b/Api/Model/Carrier/Shipping.php
@@ -24,7 +24,7 @@ use Magento\Shipping\Model\Simplexml\ElementFactory;
 use Magento\Shipping\Model\Tracking\Result\StatusFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Psr\Log\LoggerInterface;
-use Zend\Http\Client;
+use Laminas\Http\Client;
 
 /**
  * Custom shipping model
@@ -37,9 +37,9 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
     protected $storeManager;
 
     /**
-     * @var \Zend\Http\Client
+     * @var \Laminas\Http\Client
      */
-    protected $zendClient;
+    protected $laminasClient;
 
     /**
      * @var \Magento\Framework\App\ProductMetadataInterface
@@ -97,7 +97,7 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
         CurrencyFactory $currencyFactory,
         Data $directoryData,
         StockRegistryInterface $stockRegistry,
-        Client $zendClient,
+        Client $laminasClient,
         StoreManagerInterface $storeManager,
         ProductMetadataInterface $productMetadata,
         WriterInterface $configWriter,
@@ -127,7 +127,7 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
         $this->rateResultFactory = $rateFactory;
         $this->rateMethodFactory = $rateMethodFactory;
         $this->productMetadata = $productMetadata;
-        $this->zendClient = $zendClient;
+        $this->laminasClient = $laminasClient;
         $this->storeManager = $storeManager;
         $this->configWriter = $configWriter;
         $this->class = new \ReflectionClass($this);
@@ -262,19 +262,19 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
      *
      * @param string $endPoint
      * @param string $requestJson
-     * @return \Zend\Http\Response
+     * @return \Laminas\Http\Response
      */
     protected function _callApi ($endPoint, $requestJson)
     {
-        $this->zendClient->reset();
-        $this->zendClient->setUri($endPoint);
-        $this->zendClient->setMethod(\Zend\Http\Request::METHOD_POST);
-        $this->zendClient->setHeaders(['Content-Type' => 'application/json','Accept' => 'application/json']);
-        $this->zendClient->setMethod('POST');
-        $this->zendClient->setRawBody($requestJson);
-        $this->zendClient->setEncType('application/json');
-        $this->zendClient->send();
-        return $this->zendClient->getResponse();
+        $this->laminasClient->reset();
+        $this->laminasClient->setUri($endPoint);
+        $this->laminasClient->setMethod(\Laminas\Http\Request::METHOD_POST);
+        $this->laminasClient->setHeaders(['Content-Type' => 'application/json','Accept' => 'application/json']);
+        $this->laminasClient->setMethod('POST');
+        $this->laminasClient->setRawBody($requestJson);
+        $this->laminasClient->setEncType('application/json');
+        $this->laminasClient->send();
+        return $this->laminasClient->getResponse();
     }
 
     /**

--- a/Api/Model/Carrier/Shipping.php
+++ b/Api/Model/Carrier/Shipping.php
@@ -39,7 +39,7 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
     /**
      * @var \Laminas\Http\Client
      */
-    protected $laminasClient;
+    protected $client;
 
     /**
      * @var \Magento\Framework\App\ProductMetadataInterface
@@ -97,7 +97,7 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
         CurrencyFactory $currencyFactory,
         Data $directoryData,
         StockRegistryInterface $stockRegistry,
-        Client $laminasClient,
+        Client $client,
         StoreManagerInterface $storeManager,
         ProductMetadataInterface $productMetadata,
         WriterInterface $configWriter,
@@ -127,7 +127,7 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
         $this->rateResultFactory = $rateFactory;
         $this->rateMethodFactory = $rateMethodFactory;
         $this->productMetadata = $productMetadata;
-        $this->laminasClient = $laminasClient;
+        $this->client = $client;
         $this->storeManager = $storeManager;
         $this->configWriter = $configWriter;
         $this->class = new \ReflectionClass($this);
@@ -266,15 +266,15 @@ class Shipping extends AbstractCarrierOnline implements CarrierInterface
      */
     protected function _callApi ($endPoint, $requestJson)
     {
-        $this->laminasClient->reset();
-        $this->laminasClient->setUri($endPoint);
-        $this->laminasClient->setMethod(\Laminas\Http\Request::METHOD_POST);
-        $this->laminasClient->setHeaders(['Content-Type' => 'application/json','Accept' => 'application/json']);
-        $this->laminasClient->setMethod('POST');
-        $this->laminasClient->setRawBody($requestJson);
-        $this->laminasClient->setEncType('application/json');
-        $this->laminasClient->send();
-        return $this->laminasClient->getResponse();
+        $this->client->reset();
+        $this->client->setUri($endPoint);
+        $this->client->setMethod(\Laminas\Http\Request::METHOD_POST);
+        $this->client->setHeaders(['Content-Type' => 'application/json','Accept' => 'application/json']);
+        $this->client->setMethod('POST');
+        $this->client->setRawBody($requestJson);
+        $this->client->setEncType('application/json');
+        $this->client->send();
+        return $this->client->getResponse();
     }
 
     /**


### PR DESCRIPTION
# Issues installing Auctane/API via composer. 

On Magento 2.4.6, setup:di:compile after installing via Composer returns Class "Zend\Http\Client" does not exist. This is due to a well-known deprecation of the Zend libraries in favor of Laminas. Until this is mitigated, sellers on the newest supported version of Magento cannot safely install shipstation via composer. 

This PR swaps the underlying client in-place. This should be safe, as the Client interface is common between both libraries. 