### PR TITLE
Version bump to match adobe

### DIFF
--- a/Api/composer.json
+++ b/Api/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "auctane/api",
   "description": "ShipStation is a web-based shipping solution that is integrated with the Magento API for retrieving order information and updating shipping details.",
-  "version": "2.4.2",
+  "version": "2.4.5",
   "type": "magento2-module",
   "license": [
     "OSL-3.0",

--- a/Api/etc/module.xml
+++ b/Api/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Auctane_Api" setup_version="2.4.2">
+    <module name="Auctane_Api" setup_version="2.4.5">
     </module>
 </config>


### PR DESCRIPTION
Some versions did not go through and adobe does not allow edits of version numbers already submitted.
 
![magento versions](https://github.com/shipstation/plugin-magento/assets/24402859/ba9d3d97-da7b-4949-818e-e6e3eb10dbd5)

