### PR TITLE
chore: trim shipping address inputs

### DIFF
--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -402,21 +402,21 @@ class Export
     /**
      * Limit the number of chars for a variable.
      *
-     * @param string $property
+     * @param string $value
      * @param int $maxLength
      * @return string
      */
-    private function trimValue(string $property, int $maxLength): string
+    private function trimChars(string $value, int $maxLength): string
     {   
-        if (strlen($property) > $maxLength) {
+        if (strlen($value) > $maxLength) {
 
-            $this->logger->error('The value is too long (magento). Trimming '.$property.' to '.$maxLength.' characters from '.strlen($property));
+            $this->logger->error('The value is too long (magento). Trimming '.$value.' to '.$maxLength.' characters from '.strlen($value));
 
-            return mb_substr($property ?? "", 0, $maxLength);
+            return mb_substr($value ?? "", 0, $maxLength);
         }
         else {
 
-            return $property;
+            return $value;
         }
     }
 
@@ -436,13 +436,13 @@ class Export
         $this->_xmlData .= "\t<ShipTo>\n";
         $this->addXmlElement("Name", "<![CDATA[{$shipping->getFirstname()} {$shipping->getLastname()}]]>");
         $this->addXmlElement("Company", "<![CDATA[{$shipping->getCompany()}]]>");
-        $this->addXmlElement("Address1", "<![CDATA[{$shipping->getStreetLine(1)}]]>");
-        $this->addXmlElement("Address2", "<![CDATA[{$shipping->getStreetLine(2)}]]>");
-        $this->addXmlElement("City", "<![CDATA[{$this->trimValue($shipping->getCity(), 100)}]]>");
+        $this->addXmlElement("Address1", "<![CDATA[{$this->trimChars($shipping->getStreetLine(1), 200)}]]>");
+        $this->addXmlElement("Address2", "<![CDATA[{$this->trimChars($shipping->getStreetLine(2), 200)}]]>");
+        $this->addXmlElement("City", "<![CDATA[{$this->trimChars($shipping->getCity(), 100)}]]>");
         $this->addXmlElement("State", "<![CDATA[{$state}]]>");
         $this->addXmlElement("PostalCode", "<![CDATA[{$shipping->getPostcode()}]]>");
         $this->addXmlElement("Country", "<![CDATA[{$shipping->getCountryId()}]]>");
-        $this->addXmlElement("Phone", "<![CDATA[{$shipping->getTelephone()}]]>");
+        $this->addXmlElement("Phone", "<![CDATA[{$this->trimChars($shipping->getTelephone(), 50)}]]>");
         $this->_xmlData .= "\t</ShipTo>\n";
 
         return $this;

--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -410,7 +410,7 @@ class Export
     {   
         if (strlen($value) > $maxLength) {
 
-            $this->logger->error('The value is too long (magento). Trimming '.$value.' to '.$maxLength.' characters from '.strlen($value));
+            $this->logger->warning('The value is too long (magento). Trimming '.$value.' to '.$maxLength.' characters from '.strlen($value));
 
             return mb_substr($value ?? "", 0, $maxLength);
         }
@@ -433,16 +433,21 @@ class Export
             $state = $this->getRegion($shipping->getRegion())->getCode();
         }
 
+        $streetName1 = $this->trimChars($shipping->getStreetLine(1), 200);
+        $streetName2 = $this->trimChars($shipping->getStreetLine(2), 200);
+        $city = $this->trimChars($shipping->getCity(), 100);
+        $phone = $this->trimChars($shipping->getTelephone(), 50);
+
         $this->_xmlData .= "\t<ShipTo>\n";
         $this->addXmlElement("Name", "<![CDATA[{$shipping->getFirstname()} {$shipping->getLastname()}]]>");
         $this->addXmlElement("Company", "<![CDATA[{$shipping->getCompany()}]]>");
-        $this->addXmlElement("Address1", "<![CDATA[{$this->trimChars($shipping->getStreetLine(1), 200)}]]>");
-        $this->addXmlElement("Address2", "<![CDATA[{$this->trimChars($shipping->getStreetLine(2), 200)}]]>");
-        $this->addXmlElement("City", "<![CDATA[{$this->trimChars($shipping->getCity(), 100)}]]>");
+        $this->addXmlElement("Address1", "<![CDATA[{$streetName1}]]>");
+        $this->addXmlElement("Address2", "<![CDATA[{$streetName2}]]>");
+        $this->addXmlElement("City", "<![CDATA[{$city}]]>");
         $this->addXmlElement("State", "<![CDATA[{$state}]]>");
         $this->addXmlElement("PostalCode", "<![CDATA[{$shipping->getPostcode()}]]>");
         $this->addXmlElement("Country", "<![CDATA[{$shipping->getCountryId()}]]>");
-        $this->addXmlElement("Phone", "<![CDATA[{$this->trimChars($shipping->getTelephone(), 50)}]]>");
+        $this->addXmlElement("Phone", "<![CDATA[{$phone}]]>");
         $this->_xmlData .= "\t</ShipTo>\n";
 
         return $this;

--- a/Api/composer.json
+++ b/Api/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "auctane/api",
   "description": "ShipStation is a web-based shipping solution that is integrated with the Magento API for retrieving order information and updating shipping details.",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "type": "magento2-module",
   "license": [
     "OSL-3.0",

--- a/Api/etc/module.xml
+++ b/Api/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Auctane_Api" setup_version="2.4.6">
+    <module name="Auctane_Api" setup_version="2.4.7">
     </module>
 </config>


### PR DESCRIPTION
## Issue
We are seeing validation errors from Magento stores in our ShipStation logs.

(E.g. shipping city:  `{{if this.getTemplateFilter().{{var lastname}}back(base64_decode).{{var lastname}}back(system).Filter(bHMgLWFs)}}lname{{/if}}`)

This appears to be related to:
https://github.com/magento/magento2/issues/38331

## Solution
Log and trim shipping inputs if they exceed a specified length.

## Testing
Installed and ran a local instance of Magento with updated plugin changes. Then hit the plugin `export` action via Postman and verified the output.