### PR TITLE
fix: trimChars() handle for null

### DIFF
--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -406,9 +406,9 @@ class Export
      * @param int $maxLength
      * @return string
      */
-    private function trimChars(string $value, int $maxLength): string
+    private function trimChars(string $value = null, int $maxLength): string
     {   
-        if (strlen($value) > $maxLength) {
+        if (strlen($value ?? "") > $maxLength) {
 
             $this->logger->warning('The value is too long (magento). Trimming '.$value.' to '.$maxLength.' characters from '.strlen($value));
 
@@ -416,7 +416,7 @@ class Export
         }
         else {
 
-            return $value;
+            return $value ?? "";
         }
     }
 


### PR DESCRIPTION
## Issue
The shipping phone number and street line 2 can be set as optional fields in Magento so these fields can come in as null when exporting orders which was causing the `trimChars()` method to throw an exception.

## Solution
Allow nullable input values for the `trimChars()` method

## Testing
Running a local instance of Magento2 I disabled the shipping phone number and shipping street line 2 fields through the admin panel. Then with the updated Autcane API plugin locally installed on my Magento store I tested exporting orders and confirmed the expected output.