### PR TITLE
fix(SalesOrdersExport): Paging Bug

### DIFF
--- a/Api/Controller/SalesOrdersExport/Index.php
+++ b/Api/Controller/SalesOrdersExport/Index.php
@@ -97,18 +97,15 @@ class Index extends BaseAuthorizedController implements HttpPostActionInterface
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchResults = $this->orderRepository->getList($searchCriteria);
         $totalCount = $searchResults->getTotalCount();
-        if ($totalCount == 0) {
-            $response = new SalesOrdersExportResponse();
-            $response->sales_orders = [];
-            return $response;
-        }
         $totalPages = ceil($totalCount / $cursor['page_size']);
         $hasMorePages = $totalPages > $currentPage;
-        if ($currentPage > $totalPages || $currentPage <= 0) {
+
+        if ($totalCount == 0 || $currentPage > $totalPages || $currentPage <= 0) {
             $response = new SalesOrdersExportResponse();
             $response->sales_orders = [];
             return $response;
         }
+
         $orders = $searchResults->getItems();
 
         $salesOrders = [];

--- a/Api/Controller/SalesOrdersExport/Index.php
+++ b/Api/Controller/SalesOrdersExport/Index.php
@@ -97,6 +97,11 @@ class Index extends BaseAuthorizedController implements HttpPostActionInterface
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchResults = $this->orderRepository->getList($searchCriteria);
         $totalCount = $searchResults->getTotalCount();
+        if ($totalCount == 0) {
+            $response = new SalesOrdersExportResponse();
+            $response->sales_orders = [];
+            return $response;
+        }
         $totalPages = ceil($totalCount / $cursor['page_size']);
         $hasMorePages = $totalPages > $currentPage;
         if ($currentPage > $totalPages) {

--- a/Api/Controller/SalesOrdersExport/Index.php
+++ b/Api/Controller/SalesOrdersExport/Index.php
@@ -104,11 +104,10 @@ class Index extends BaseAuthorizedController implements HttpPostActionInterface
         }
         $totalPages = ceil($totalCount / $cursor['page_size']);
         $hasMorePages = $totalPages > $currentPage;
-        if ($currentPage > $totalPages) {
-            throw new BadRequestException('Current page is too big');
-        }
-        if ($currentPage <= 0) {
-            throw new BadRequestException('Current page is too small');
+        if ($currentPage > $totalPages || $currentPage <= 0) {
+            $response = new SalesOrdersExportResponse();
+            $response->sales_orders = [];
+            return $response;
         }
         $orders = $searchResults->getItems();
 

--- a/Api/composer.json
+++ b/Api/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "auctane/api",
   "description": "ShipStation is a web-based shipping solution that is integrated with the Magento API for retrieving order information and updating shipping details.",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "type": "magento2-module",
   "license": [
     "OSL-3.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# [2.5.2-beta] - 2025-04-17
+### Update
+- Fixed Issue with page sizing with empty results
+
 ## [2.5.1-beta] - 2024-11-01
 ### Added
 - Updated custom store export implementation to include the payment method.


### PR DESCRIPTION
# Sales Orders Export Paging Bug

When the request comes in for a page that doesn't exist or if there are no orders in the system that match the criteria we should just immediately return a successful response with an empty orders array.