### PR TITLE
Add UPC Mapping ORD-4296

### DIFF
--- a/Api/Model/Config/Source/UpcMapping.php
+++ b/Api/Model/Config/Source/UpcMapping.php
@@ -30,16 +30,23 @@ class UpcMapping implements \Magento\Framework\Option\ArrayInterface
     public function toOptionArray()
     {
         $attributesCollection = $this->_factory->create();
-        $attributes = [['value' => '', 'label' => __('-- Please Select --')]];
+        $pleaseSelectOption = [['value' => '', 'label' => __('-- Please Select --')]];
+        $attributeOptions = [];
         
         foreach ($attributesCollection as $attribute) {
             $code = $attribute->getAttributeCode();
             $label = $attribute->getFrontendLabel();
             if ($label) {
-                $attributes[] = ['value' => $code, 'label' => $label];
+                $attributeOptions[] = ['value' => $code, 'label' => $label];
             }
         }
         
-        return $attributes;
+        // Sort attributes alphabetically by label
+        usort($attributeOptions, function ($a, $b) {
+            return strcmp($a['label'], $b['label']);
+        });
+        
+        // Merge the "Please Select" option with the sorted attributes
+        return array_merge($pleaseSelectOption, $attributeOptions);
     }
 }

--- a/Api/Model/Config/Source/UpcMapping.php
+++ b/Api/Model/Config/Source/UpcMapping.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Auctane\Api\Model\Config\Source;
+
+class UpcMapping implements \Magento\Framework\Option\ArrayInterface
+{
+    /**
+     * Attribute collection factory
+     *
+     * @var \Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory
+     */
+    private $_factory;
+
+    /**
+     * Collection factory
+     *
+     * @param \Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory $factory collection
+     */
+    public function __construct(
+        \Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory $factory
+    ) {
+        $this->_factory = $factory;
+    }
+
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $attributesCollection = $this->_factory->create();
+        $attributes = [['value' => '', 'label' => __('-- Please Select --')]];
+        
+        foreach ($attributesCollection as $attribute) {
+            $code = $attribute->getAttributeCode();
+            $label = $attribute->getFrontendLabel();
+            if ($label) {
+                $attributes[] = ['value' => $code, 'label' => $label];
+            }
+        }
+        
+        return $attributes;
+    }
+}

--- a/Api/etc/adminhtml/system.xml
+++ b/Api/etc/adminhtml/system.xml
@@ -40,6 +40,12 @@
                     <label>Import Child Products</label>
                     <source_model>Auctane\Api\Model\Config\Source\ImportChild</source_model>
                 </field>
+                <field id="upc_mapping" translate="label" type="select" sortOrder="22"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>UPC Mapping</label>
+                    <comment>Select product attribute to use as UPC value in order exports</comment>
+                    <source_model>Auctane\Api\Model\Config\Source\UpcMapping</source_model>
+                </field>
                 <field id="custom_invoicing" translate="label" type="select" sortOrder="25"
                        showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Custom/Auto Invoicing Enabled</label>

--- a/Api/etc/module.xml
+++ b/Api/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Auctane_Api" setup_version="2.4.8">
+    <module name="Auctane_Api" setup_version="2.4.9">
     </module>
 </config>

--- a/Api/etc/module.xml
+++ b/Api/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Auctane_Api" setup_version="2.4.9">
+    <module name="Auctane_Api" setup_version="2.5.3">
     </module>
 </config>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Update
 - Fixed Issue with page sizing with empty results
 
+## [2.4.9] - 2025-05-14
+### Added
+- Added UPC mapping functionality to order exports
+- Added ability to select product attribute to use as UPC value in order exports
+
 ## [2.5.1-beta] - 2024-11-01
 ### Added
 - Updated custom store export implementation to include the payment method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-# [2.5.2-beta] - 2025-04-17
-### Update
-- Fixed Issue with page sizing with empty results
-
-## [2.4.9] - 2025-05-14
+## [2.5.3] - 2025-05-14
 ### Added
 - Added UPC mapping functionality to order exports
 - Added ability to select product attribute to use as UPC value in order exports
 
-## [2.5.1-beta] - 2024-11-01
+# [2.5.2] - 2025-04-17
+### Update
+- Fixed Issue with page sizing with empty results
+
+## [2.5.1] - 2024-11-01
 ### Added
 - Updated custom store export implementation to include the payment method.
 ### Update
 - Release Job 
 
-## [2.5.0-beta] - 2024-10-30
+## [2.5.0] - 2024-10-30
 ### Added
 - ShipEngine Connect Models
 - Release Action


### PR DESCRIPTION
This pull request introduces a new feature for UPC mapping in order exports, along with supporting changes to the codebase and configuration files. It includes the addition of a new attribute for UPC mapping, a method to retrieve UPC values, and updates to the configuration interface to allow selecting a product attribute for UPC mapping.


![image](https://github.com/user-attachments/assets/8f704acd-2e8a-48fd-baa1-7e3fbfab4764)
