### PR TITLE
2.5.4 Fix const string

### DIFF
--- a/Api/Controller/ShipmentNotification/Index.php
+++ b/Api/Controller/ShipmentNotification/Index.php
@@ -26,7 +26,7 @@ use Psr\Log\LoggerInterface;
 class Index extends BaseAuthorizedController implements HttpPostActionInterface
 {
     /** @var string Invoice Comment */
-    protected const string COMMENT = 'Issued by Auctane ShipStation.';
+    protected const COMMENT = 'Issued by Auctane ShipStation.';
     /** @var OrderRepositoryInterface  */
     protected OrderRepositoryInterface $orderRepository;
     /** @var ShipmentRepositoryInterface  */

--- a/Api/etc/module.xml
+++ b/Api/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Auctane_Api" setup_version="2.5.3">
+    <module name="Auctane_Api" setup_version="2.5.4">
     </module>
 </config>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.5.4] - 2025-05-19
+### Update
+- Removed const string from ShipmentNotification [ORD-4355]() Caused issued in PHP 8.2 and below
+
 ## [2.5.3] - 2025-05-14
 ### Added
 - Added UPC mapping functionality to order exports


### PR DESCRIPTION
This pull request includes a version update for the `Auctane_Api` module and a fix for compatibility issues with PHP 8.2 and below. The most important changes are:

### Version Update:
* Updated the `setup_version` in `Api/etc/module.xml` from `2.5.3` to `2.5.4`.

### Compatibility Fix:
* Removed the `const string` type declaration in `Api/Controller/ShipmentNotification/Index.php` to resolve compatibility issues with PHP 8.2 and below.

### Documentation:
* Added a new entry for version `2.5.4` in `CHANGELOG.md`, documenting the removal of the `const string` type declaration to address the PHP compatibility issue.