### PR TITLE
Bump to 2.5.6

### DIFF
--- a/Api/composer.json
+++ b/Api/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "auctane/api",
   "description": "ShipStation is a web-based shipping solution that is integrated with the Magento API for retrieving order information and updating shipping details.",
-  "version": "2.5.4",
+  "version": "2.5.6",
   "type": "magento2-module",
   "license": [
     "OSL-3.0",

--- a/Api/etc/module.xml
+++ b/Api/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Auctane_Api" setup_version="2.5.4">
+    <module name="Auctane_Api" setup_version="2.5.6">
     </module>
 </config>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [2.5.4] - 2025-05-19
+## [2.5.6] - 2025-05-19
 ### Update
 - Removed const string from ShipmentNotification [ORD-4355]() Caused issued in PHP 8.2 and below
+- Bumped to resync with Adobes published version
 
 ## [2.5.3] - 2025-05-14
 ### Added


### PR DESCRIPTION
There is an issue within Adobes extension publisher that prevented 2.5.4 from being published, after looking into it 2.5.5 will also block release. So I am going to sync up the github version with the release version in 2.5.6