### PR TITLE
PHP 8.4 compatibility updates

### DIFF
--- a/Api/Model/Action/Export.php
+++ b/Api/Model/Action/Export.php
@@ -414,7 +414,7 @@ class Export
      * @param int $maxLength
      * @return string
      */
-    private function trimChars(string $value = null, int $maxLength): string
+    private function trimChars(?string $value, int $maxLength): string
     {
         if (strlen($value ?? "") > $maxLength) {
 

--- a/Api/Model/OrderSourceAPI/Models/Address.php
+++ b/Api/Model/OrderSourceAPI/Models/Address.php
@@ -46,7 +46,7 @@ class Address
      * Address constructor.
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data !== null) {
             $this->name = $data['name'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/Buyer.php
+++ b/Api/Model/OrderSourceAPI/Models/Buyer.php
@@ -39,7 +39,7 @@ class Buyer
      * Buyer constructor.
      * @param array|null $data JSON data to populate the Buyer class properties
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data !== null) {
             $this->buyer_id = $data['buyer_id'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/InventoryFetchCriteria.php
+++ b/Api/Model/OrderSourceAPI/Models/InventoryFetchCriteria.php
@@ -16,7 +16,7 @@ class InventoryFetchCriteria
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->skus = $data['skus'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/InventoryFetchItem.php
+++ b/Api/Model/OrderSourceAPI/Models/InventoryFetchItem.php
@@ -16,7 +16,7 @@ class InventoryFetchItem extends InventoryItemBase
      *
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
         if ($data) {

--- a/Api/Model/OrderSourceAPI/Models/InventoryItemBase.php
+++ b/Api/Model/OrderSourceAPI/Models/InventoryItemBase.php
@@ -32,7 +32,7 @@ abstract class InventoryItemBase
      *
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->sku = $data['sku'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/InventoryItemError.php
+++ b/Api/Model/OrderSourceAPI/Models/InventoryItemError.php
@@ -29,7 +29,7 @@ class InventoryItemError
      *
      * @param array|null $data JSON data to initialize properties
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->integration_inventory_item_id = $data['integration_inventory_item_id'] ?? '';

--- a/Api/Model/OrderSourceAPI/Models/OriginalOrderSource.php
+++ b/Api/Model/OrderSourceAPI/Models/OriginalOrderSource.php
@@ -13,7 +13,7 @@ class OriginalOrderSource
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->source_id = $data['source_id'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/PickupLocation.php
+++ b/Api/Model/OrderSourceAPI/Models/PickupLocation.php
@@ -14,7 +14,7 @@ class PickupLocation
      *
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data !== null) {
             $this->carrier_id = $data['carrier_id'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/Product.php
+++ b/Api/Model/OrderSourceAPI/Models/Product.php
@@ -27,7 +27,7 @@ class Product
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data !== null) {
             $this->product_id = $data['product_id'];

--- a/Api/Model/OrderSourceAPI/Models/ProductDetail.php
+++ b/Api/Model/OrderSourceAPI/Models/ProductDetail.php
@@ -11,7 +11,7 @@ class ProductDetail
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->name = $data['name'];

--- a/Api/Model/OrderSourceAPI/Models/ProductIdentifiers.php
+++ b/Api/Model/OrderSourceAPI/Models/ProductIdentifiers.php
@@ -19,7 +19,7 @@ class ProductIdentifiers
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data !== null) {
             $this->sku = $data['sku'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/ProductUrls.php
+++ b/Api/Model/OrderSourceAPI/Models/ProductUrls.php
@@ -13,7 +13,7 @@ class ProductUrls
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data !== null) {
             $this->product_url = $data['product_url'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/RequestedFulfillment.php
+++ b/Api/Model/OrderSourceAPI/Models/RequestedFulfillment.php
@@ -20,7 +20,7 @@ class RequestedFulfillment
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->requested_fulfillment_id = $data['requested_fulfillment_id'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/RequestedFulfillmentExtensions.php
+++ b/Api/Model/OrderSourceAPI/Models/RequestedFulfillmentExtensions.php
@@ -13,7 +13,7 @@ class RequestedFulfillmentExtensions
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->custom_field_1 = $data['custom_field_1'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/SalesOrder.php
+++ b/Api/Model/OrderSourceAPI/Models/SalesOrder.php
@@ -45,7 +45,7 @@ class SalesOrder
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->order_id = $data['order_id'];

--- a/Api/Model/OrderSourceAPI/Models/SalesOrderExportCriteria.php
+++ b/Api/Model/OrderSourceAPI/Models/SalesOrderExportCriteria.php
@@ -12,7 +12,7 @@ class SalesOrderExportCriteria
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->from_date_time = $data['from_date_time'] ?? null;
         $this->to_date_time = $data['to_date_time'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/SalesOrderItem.php
+++ b/Api/Model/OrderSourceAPI/Models/SalesOrderItem.php
@@ -37,7 +37,7 @@ class SalesOrderItem
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->line_item_id = $data['line_item_id'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/ShipmentNotification.php
+++ b/Api/Model/OrderSourceAPI/Models/ShipmentNotification.php
@@ -44,7 +44,7 @@ class ShipmentNotification
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->notification_id = $data['notification_id'];

--- a/Api/Model/OrderSourceAPI/Models/ShipmentNotificationItem.php
+++ b/Api/Model/OrderSourceAPI/Models/ShipmentNotificationItem.php
@@ -18,7 +18,7 @@ class ShipmentNotificationItem
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->line_item_id = $data['line_item_id'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/ShipmentNotificationResult.php
+++ b/Api/Model/OrderSourceAPI/Models/ShipmentNotificationResult.php
@@ -27,7 +27,7 @@ class ShipmentNotificationResult
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->notification_id = $data['notification_id'] ?? null;

--- a/Api/Model/OrderSourceAPI/Models/Weight.php
+++ b/Api/Model/OrderSourceAPI/Models/Weight.php
@@ -14,7 +14,7 @@ class Weight
      * Weight constructor.
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->unit = $data['unit'];

--- a/Api/Model/OrderSourceAPI/Requests/InventoryFetchRequest.php
+++ b/Api/Model/OrderSourceAPI/Requests/InventoryFetchRequest.php
@@ -26,7 +26,7 @@ class InventoryFetchRequest extends RequestBase
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
         if ($data) {

--- a/Api/Model/OrderSourceAPI/Requests/InventoryPushRequest.php
+++ b/Api/Model/OrderSourceAPI/Requests/InventoryPushRequest.php
@@ -28,7 +28,7 @@ class InventoryPushRequest extends RequestBase
      *
      * @param array|null $data JSON payload as an associative array.
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if ($data) {
             $this->items = [];

--- a/Api/Model/OrderSourceAPI/Requests/ShipmentNotificationRequest.php
+++ b/Api/Model/OrderSourceAPI/Requests/ShipmentNotificationRequest.php
@@ -12,7 +12,7 @@ class ShipmentNotificationRequest extends RequestBase
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
         if ($data) {


### PR DESCRIPTION
PHP 8.4: make implicitly-nullable param types explicit

- Replace signatures like `Type $x = null` with `?Type $x = null` (or `Type|null`)
- Eliminates PHP 8.4 deprecations; prepares for PHP 9
- No behavioral changes; note potential override adjustments for extenders